### PR TITLE
Refactor audit package: Persistent file descriptor, thread-safe writes, and created_at field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ deps:
 test:
 	go test -v ./...
 
+test-short:
+	go test ./...
+
 clean:
 	rm -rf bin/
 
@@ -87,7 +90,15 @@ compose-build:
 compose-build-nocache:
 	$(COMPOSE) build --no-cache
 
-up:
+init:
+	@echo "=> Preparing environment..."
+	@mkdir -p audit-logs
+	@if [ "$$(stat -c %u audit-logs)" != "10001" ]; then \
+		echo "=> Setting permissions for audit-logs. Sudo password might be required."; \
+		sudo chown -R 10001:10001 audit-logs; \
+	fi
+
+up: init
 	$(COMPOSE) up -d --build
 
 up-infra:
@@ -148,4 +159,4 @@ lint:
         compose-build compose-build-nocache up down downfull logs logs-bot \
         restart clean-volumes ps \
         db tables databases query dump \
-        dev deploy reset lint
+        dev deploy reset lint test-short

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -6,13 +6,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
 type FileStorage struct {
+	sync.Mutex
 	filePath string
-	logs     chan Log
-	done     chan struct{}
+	file     *os.File
 }
 
 func NewFileStorage(auditDir string) (*FileStorage, error) {
@@ -21,8 +22,7 @@ func NewFileStorage(auditDir string) (*FileStorage, error) {
 
 	if auditDir == "" {
 		auditDir = "audit-logs"
-		log.Info("no audit directory specified",
-			slog.String("default", auditDir))
+		log.Info("no audit directory specified", slog.String("default", auditDir))
 	}
 
 	if err := os.MkdirAll(auditDir, 0755); err != nil {
@@ -31,57 +31,50 @@ func NewFileStorage(auditDir string) (*FileStorage, error) {
 
 	logPath := filepath.Join(auditDir, "audit.json")
 	absPath, _ := filepath.Abs(logPath)
+
+	// Открываем файл на весь срок жизни приложения
 	file, err := os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to open file: %w", op, err)
 	}
-	log.Info("audit file location determined",
-		slog.String("path", absPath))
 
-	fs := &FileStorage{
-		filePath: logPath,
-		logs:     make(chan Log, 30),
-		done:     make(chan struct{}),
-	}
-	go fs.worker(file)
+	log.Info("audit file location determined", slog.String("path", absPath))
 
-	return fs, nil
-}
-
-func (fs *FileStorage) worker(file *os.File) {
-	defer func() {
-		if err := file.Close(); err != nil {
-			slog.Error("failed to close the audit file in worker",
-				slog.String("error", err.Error()),
-				slog.String("path", fs.filePath))
-		}
-		close(fs.done)
-	}()
-
-	for s := range fs.logs {
-		if s.At.IsZero() {
-			s.At = time.Now()
-		}
-
-		logData, err := json.Marshal(s)
-		if err != nil {
-			slog.Error("failed to serialize audit log", slog.String("error", err.Error()))
-			continue
-		}
-
-		if _, err := file.Write(append(logData, '\n')); err != nil {
-			slog.Error("failed to write audit log", slog.String("error", err.Error()))
-		}
-	}
+	return &FileStorage{
+		filePath: absPath,
+		file:     file,
+	}, nil
 }
 
 func (fs *FileStorage) Save(s Log) error {
-	fs.logs <- s
+	if s.At.IsZero() {
+		s.At = time.Now()
+	}
+
+	logData, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to serialize audit log: %w", err)
+	}
+
+	logData = append(logData, '\n')
+
+	fs.Lock()
+	defer fs.Unlock()
+
+	if _, err := fs.file.Write(logData); err != nil {
+		return fmt.Errorf("failed to write audit log to file: %w", err)
+	}
+
 	return nil
 }
 
 func (fs *FileStorage) Close() error {
-	close(fs.logs)
-	<-fs.done
-	return nil
+	fs.Lock()
+	defer fs.Unlock()
+
+	if err := fs.file.Sync(); err != nil {
+		slog.Error("failed to sync audit file on close", slog.String("error", err.Error()))
+	}
+
+	return fs.file.Close()
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,7 +32,6 @@ func NewFileStorage(auditDir string) (*FileStorage, error) {
 	logPath := filepath.Join(auditDir, "audit.json")
 	absPath, _ := filepath.Abs(logPath)
 
-	// Открываем файл на весь срок жизни приложения
 	file, err := os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to open file: %w", op, err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -6,10 +6,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type FileStorage struct {
 	filePath string
+	logs     chan Log
+	done     chan struct{}
 }
 
 func NewFileStorage(auditDir string) (*FileStorage, error) {
@@ -28,44 +31,57 @@ func NewFileStorage(auditDir string) (*FileStorage, error) {
 
 	logPath := filepath.Join(auditDir, "audit.json")
 	absPath, _ := filepath.Abs(logPath)
+	file, err := os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to open file: %w", op, err)
+	}
 	log.Info("audit file location determined",
 		slog.String("path", absPath))
 
-	return &FileStorage{filePath: absPath}, nil
+	fs := &FileStorage{
+		filePath: logPath,
+		logs:     make(chan Log, 30),
+		done:     make(chan struct{}),
+	}
+	go fs.worker(file)
+
+	return fs, nil
 }
 
-func (fs FileStorage) Save(s any) error {
-	const op = "audit.Save"
-
-	file, err := os.OpenFile(fs.filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("%s: failed to open file: %w", op, err)
-	}
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			slog.Error("failed to close the audit file",
-				slog.Group("error",
-					slog.String("message", err.Error()),
-					slog.String("component", "audit.Save"),
-					slog.String("path", fs.filePath)))
+func (fs *FileStorage) worker(file *os.File) {
+	defer func() {
+		if err := file.Close(); err != nil {
+			slog.Error("failed to close the audit file in worker",
+				slog.String("error", err.Error()),
+				slog.String("path", fs.filePath))
 		}
-	}(file)
+		close(fs.done)
+	}()
 
-	log, err := serialize(s)
-	if err != nil {
-		return fmt.Errorf("failed to serialize an audit log: %w", err)
+	for s := range fs.logs {
+		if s.At.IsZero() {
+			s.At = time.Now()
+		}
+
+		logData, err := json.Marshal(s)
+		if err != nil {
+			slog.Error("failed to serialize audit log", slog.String("error", err.Error()))
+			continue
+		}
+
+		if _, err := file.Write(append(logData, '\n')); err != nil {
+			slog.Error("failed to write audit log", slog.String("error", err.Error()))
+		}
 	}
-	if _, err = file.Write(log); err != nil {
-		return fmt.Errorf("failed to write to the audit file: %w", err)
-	}
+}
+
+func (fs *FileStorage) Save(s Log) error {
+	fs.logs <- s
 	return nil
 }
 
-func serialize(s any) ([]byte, error) {
-	b, err := json.Marshal(s)
-	if err != nil {
-		return nil, err
-	}
-	return append(b, '\n'), nil
+func (fs *FileStorage) Close() error {
+	close(fs.logs)
+	<-fs.done
+	return nil
 }

--- a/internal/audit/audit_model.go
+++ b/internal/audit/audit_model.go
@@ -5,6 +5,6 @@ import "time"
 type Log struct {
 	Code   string    `json:"code"`
 	Action string    `json:"action"`
-	By     string    `json:"by"`
-	At     time.Time `json:"at"`
+	By     string    `json:"created_by"`
+	At     time.Time `json:"created_at"`
 }

--- a/internal/audit/audit_model.go
+++ b/internal/audit/audit_model.go
@@ -1,7 +1,10 @@
 package audit
 
+import "time"
+
 type Log struct {
-	Code   string `json:"code"`
-	Action string `json:"action"`
-	By     string `json:"by"`
+	Code   string    `json:"code"`
+	Action string    `json:"action"`
+	By     string    `json:"by"`
+	At     time.Time `json:"at"`
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -111,8 +111,6 @@ func TestFileStorage_Save(t *testing.T) {
 			err = storage.Save(tt.input)
 			require.NoError(t, err)
 
-			// IMPORTANT: Close the storage. This blocks execution until
-			// the worker writes all pending data to disk and shuts down.
 			err = storage.Close()
 			require.NoError(t, err)
 
@@ -131,7 +129,7 @@ func TestNewFileStorage(t *testing.T) {
 		storage, err := NewFileStorage(auditDir)
 		require.NoError(t, err)
 		require.NotNil(t, storage)
-		defer storage.Close() // Ensure the goroutine is closed
+		defer storage.Close()
 
 		_, err = os.Stat(auditDir)
 		require.NoError(t, err, "directory should be created")
@@ -154,7 +152,6 @@ func TestNewFileStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, storage)
 		defer storage.Close()
-
 		_, err = os.Stat("audit-logs")
 		require.NoError(t, err)
 	})

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -11,57 +11,57 @@ import (
 func TestFileStorage_Save(t *testing.T) {
 	tests := []struct {
 		name         string
-		input        any
+		input        Log
 		setupFunc    func(t *testing.T, tmpDir string)
-		wantErr      bool
 		validateFunc func(t *testing.T, tmpDir string)
 	}{
 		{
 			name: "successful write to new file",
-			input: map[string]string{
-				"code":   "test",
-				"action": "created",
-				"by":     "admin",
+			input: Log{
+				Code:   "test",
+				Action: "created",
+				By:     "admin",
 			},
-			wantErr: false,
 			validateFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				content, err := os.ReadFile(logPath)
 				require.NoError(t, err)
-				require.Equal(t, "{\"action\":\"created\",\"by\":\"admin\",\"code\":\"test\"}\n", string(content))
+
+				// Check for the presence of keys, since the "at" field is dynamically generated
+				require.Contains(t, string(content), `"action":"created"`)
+				require.Contains(t, string(content), `"created_by":"admin"`)
+				require.Contains(t, string(content), `"code":"test"`)
 			},
 		},
 		{
 			name: "append to existing file",
-			input: map[string]string{
-				"code":   "second",
-				"action": "updated",
-				"by":     "user",
+			input: Log{
+				Code:   "second",
+				Action: "updated",
+				By:     "user",
 			},
-			wantErr: false,
 			setupFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				err := os.MkdirAll(filepath.Dir(logPath), 0755)
 				require.NoError(t, err)
-				err = os.WriteFile(logPath, []byte("{\"code\":\"first\",\"action\":\"created\",\"by\":\"admin\"}\n"), 0644)
+				err = os.WriteFile(logPath, []byte("{\"code\":\"first\",\"action\":\"created\",\"created_by\":\"admin\"}\n"), 0644)
 				require.NoError(t, err)
 			},
 			validateFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				content, err := os.ReadFile(logPath)
 				require.NoError(t, err)
-				require.Contains(t, string(content), "\"code\":\"first\"")
-				require.Contains(t, string(content), "\"code\":\"second\"")
+				require.Contains(t, string(content), `"code":"first"`)
+				require.Contains(t, string(content), `"code":"second"`)
 			},
 		},
 		{
 			name: "create directory if not exists",
-			input: map[string]string{
-				"code":   "new",
-				"action": "created",
-				"by":     "system",
+			input: Log{
+				Code:   "new",
+				Action: "created",
+				By:     "system",
 			},
-			wantErr: false,
 			validateFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				_, err := os.Stat(filepath.Dir(logPath))
@@ -69,83 +69,29 @@ func TestFileStorage_Save(t *testing.T) {
 			},
 		},
 		{
-			name:    "write empty struct",
-			input:   struct{}{},
-			wantErr: false,
+			name:  "write empty struct",
+			input: Log{},
 			validateFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				content, err := os.ReadFile(logPath)
 				require.NoError(t, err)
-				require.Equal(t, "{}\n", string(content))
-			},
-		},
-		{
-			name: "attempt to write to readonly file",
-			input: map[string]string{
-				"code":   "readonly",
-				"action": "updated",
-				"by":     "test",
-			},
-			wantErr: true,
-			setupFunc: func(t *testing.T, tmpDir string) {
-				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
-				err := os.MkdirAll(filepath.Dir(logPath), 0755)
-				require.NoError(t, err)
-				err = os.WriteFile(logPath, []byte("{\"existing\":\"data\"}\n"), 0644)
-				require.NoError(t, err)
-				err = os.Chmod(logPath, 0444)
-				require.NoError(t, err)
-			},
-			validateFunc: func(t *testing.T, tmpDir string) {
-				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
-				err := os.Chmod(logPath, 0644)
-				require.NoError(t, err)
-			},
-		},
-		{
-			name:    "write nil data",
-			input:   nil,
-			wantErr: false,
-			validateFunc: func(t *testing.T, tmpDir string) {
-				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
-				content, err := os.ReadFile(logPath)
-				require.NoError(t, err)
-				require.Equal(t, "null\n", string(content))
-			},
-		},
-		{
-			name: "write nested structure",
-			input: map[string]any{
-				"code":   "nested",
-				"action": "created",
-				"meta": map[string]string{
-					"ip":   "127.0.0.1",
-					"user": "admin",
-				},
-			},
-			wantErr: false,
-			validateFunc: func(t *testing.T, tmpDir string) {
-				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
-				content, err := os.ReadFile(logPath)
-				require.NoError(t, err)
-				require.Contains(t, string(content), "\"meta\"")
-				require.Contains(t, string(content), "\"ip\"")
+				// An empty struct will have at least the "at" field populated
+				require.Contains(t, string(content), `"created_at":`)
+				require.Contains(t, string(content), `"code":""`)
 			},
 		},
 		{
 			name: "special characters in data",
-			input: map[string]string{
-				"code":   "test\t\n\r",
-				"action": "created",
-				"by":     "admin",
+			input: Log{
+				Code:   "test\t\n\r",
+				Action: "created",
+				By:     "admin",
 			},
-			wantErr: false,
 			validateFunc: func(t *testing.T, tmpDir string) {
 				logPath := filepath.Join(tmpDir, "audit-logs", "audit.json")
 				content, err := os.ReadFile(logPath)
 				require.NoError(t, err)
-				require.Contains(t, string(content), "\\t")
-				require.Contains(t, string(content), "\\n")
+				require.Contains(t, string(content), `test\t\n\r`)
 			},
 		},
 	}
@@ -163,12 +109,12 @@ func TestFileStorage_Save(t *testing.T) {
 			require.NoError(t, err)
 
 			err = storage.Save(tt.input)
+			require.NoError(t, err)
 
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			// IMPORTANT: Close the storage. This blocks execution until
+			// the worker writes all pending data to disk and shuts down.
+			err = storage.Close()
+			require.NoError(t, err)
 
 			if tt.validateFunc != nil {
 				tt.validateFunc(t, tmpDir)
@@ -185,6 +131,7 @@ func TestNewFileStorage(t *testing.T) {
 		storage, err := NewFileStorage(auditDir)
 		require.NoError(t, err)
 		require.NotNil(t, storage)
+		defer storage.Close() // Ensure the goroutine is closed
 
 		_, err = os.Stat(auditDir)
 		require.NoError(t, err, "directory should be created")
@@ -206,6 +153,7 @@ func TestNewFileStorage(t *testing.T) {
 		storage, err := NewFileStorage("")
 		require.NoError(t, err)
 		require.NotNil(t, storage)
+		defer storage.Close()
 
 		_, err = os.Stat("audit-logs")
 		require.NoError(t, err)
@@ -213,8 +161,7 @@ func TestNewFileStorage(t *testing.T) {
 
 	t.Run("fails when cannot create directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		// Create a regular file where a directory is expected,
-		// so MkdirAll fails on all platforms.
+
 		blockingFile := filepath.Join(tmpDir, "not-a-dir")
 		err := os.WriteFile(blockingFile, []byte{}, 0644)
 		require.NoError(t, err)

--- a/internal/service/promo/promo.go
+++ b/internal/service/promo/promo.go
@@ -15,7 +15,7 @@ type Repository interface {
 }
 
 type AuditSaver interface {
-	Save(s any) error
+	Save(s audit.Log) error
 }
 
 type TxManager interface {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ var (
 )
 
 func main() {
-
 	DevLvl := os.Getenv(cfg.EnvDevLevel)
 	if DevLvl == "" {
 		DevLvl = "local"
@@ -69,7 +68,6 @@ func main() {
 	bot.Debug = strings.ToLower(debugMode) == "true" || debugMode == "1"
 
 	filePath := os.Getenv(cfg.EnvAuditLogsDir)
-
 	log.Debug("filePath", "path", filePath)
 
 	auditStorage, err := audit.NewFileStorage(filePath)
@@ -159,7 +157,7 @@ func main() {
 	}
 
 	wg.Wait()
-	shutdown(stateStorage, db)
+	shutdown(stateStorage, db, auditStorage)
 }
 
 func establishConnections(ctx context.Context) (stateStorage wizard.StateStorage, db *pgxpool.Pool) {
@@ -184,7 +182,6 @@ func establishConnections(ctx context.Context) (stateStorage wizard.StateStorage
 		os.Getenv(cfg.EnvPostgresPassword),
 		dbName)
 	db = storage.ConnectToDatabase(ctx, dbConfig)
-	//storage.RunMigrations(dbConfig, os.Getenv("MIGRATIONS_REPO"))
 	metrics.RegisterMetricsForPgxPoolStat(db, dbName)
 	return
 }
@@ -205,20 +202,24 @@ func initHandlers(
 		promoHandler,
 		handlers.NewStats(appEnv, stateStorage, service),
 	}
-	callbackHandlers = []base.CallbackHandler{
-		// handlers.NewRevokeCallbackHandler(appEnv),
-	}
+	callbackHandlers = []base.CallbackHandler{}
 	metrics.RegisterMessageHandlerCounters(messageHandlers...)
 	return
 }
 
-func shutdown(stateStorage wizard.StateStorage, db *pgxpool.Pool) {
+func shutdown(stateStorage wizard.StateStorage, db *pgxpool.Pool, auditStorage *audit.FileStorage) {
 	db.Close()
 	if err := stateStorage.Close(); err != nil {
 		slog.Error("failed to close state storage",
 			slog.Group("error",
 				slog.String("message", err.Error()),
 				slog.String("component", "StateStorage.Close")))
+	}
+	if err := auditStorage.Close(); err != nil {
+		slog.Error("failed to close audit storage",
+			slog.Group("error",
+				slog.String("message", err.Error()),
+				slog.String("component", "AuditStorage.Close")))
 	}
 }
 
@@ -237,27 +238,21 @@ func getLogLevel(env string) slog.Level {
 
 func initLogger(env string) *slog.Logger {
 	lvl := getLogLevel(env)
-	opts := &slog.HandlerOptions{
-		Level: lvl,
-	}
+	opts := &slog.HandlerOptions{Level: lvl}
 	var handler slog.Handler
 	if env == "local" {
 		handler = slog.NewTextHandler(os.Stdout, opts)
 	} else {
 		handler = slog.NewJSONHandler(os.Stdout, opts)
 	}
-
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
-
 	return logger
 }
 
-func restApiStart(appEnv *base.ApplicationEnv, audit *audit.FileStorage, manager *repo.TxManager) http.Handler {
-	//appEnv *base.ApplicationEnv, repo *repo.Promo, audit audit.SaverStorage, manager repo.TxManager
+func restApiStart(appEnv *base.ApplicationEnv, auditS *audit.FileStorage, manager *repo.TxManager) http.Handler {
 	promoRepo := repo.NewPromo(appEnv)
-	service := promo.NewSaveService(promoRepo, audit, manager)
+	service := promo.NewSaveService(promoRepo, auditS, manager)
 	restHandler := handlers.NewOneTimePromoHandler(service)
-
 	return restHandler.GeneratePromo()
 }


### PR DESCRIPTION
Related Issue: Closes #24  and #18.

## Description

This PR significantly improves the performance and reliability of the audit package by eliminating the high I/O overhead of opening and closing the file descriptor on every log save. It introduces a persistent, thread-safe file writer and resolves the issue with missing timestamps in the audit logs.

## Key Changes
Thread-Safe Synchronous File Writer: * Replaced the old implementation that opened and closed the file descriptor on every Save() call.

The file is now opened once upon initialization. Concurrent writes from different handler goroutines are protected using a sync.Mutex to prevent race conditions and corrupted JSON lines, while ensuring immediate error reporting if a write fails.

Strong Typing & Timestamp (#24): * Updated the Log struct to use explicit fields (code, action, created_by, created_at).

Automatically assigns time.Now() to created_at inside the Save() method if it's missing.

Changed the Save() signature to accept the Log struct instead of any, ensuring compile-time type safety.

Graceful Shutdown: * Added a Close() method to FileStorage to properly flush pending OS buffers to disk (file.Sync()) and safely close the file descriptor.

Integrated auditStorage.Close() into the main application shutdown sequence in main.go.

Docker / Makefile Fixes: * Added an init target in the Makefile to automatically manage the audit-logs directory creation and permissions (chown 10001:10001), fixing the permission denied issue during docker compose up.

Tests Updated: * Rewrote audit_test.go to properly test the new synchronous behavior, utilizing Close() for safe validation.

Updated assertions to account for the dynamic created_at field and strict JSON serialization keys.
## Testing
- [x] Unit tests passed (make test / make test-short).
- [x] Tested locally via Docker Compose.
- [x] Verified that logs are successfully appended and no data is lost during a graceful shutdown.
